### PR TITLE
Prevent losing items after backpack size is reduced

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Please consider donating to support me and help me put more time into my plugins
   "View Backpack Syntax": "Syntax: /viewbackpack <name or id>",
   "User ID not Found": "Could not find player with ID '{0}'",
   "User Name not Found": "Could not find player with name '{0}'",
-  "Multiple Players Found": "Multiple matching players found:\n{0}"
+  "Multiple Players Found": "Multiple matching players found:\n{0}",
+  "Backpack Over Capacity": "Your backpack was over capacity. Overflowing items were added to your inventory or dropped."
 }
 ```
 


### PR DESCRIPTION
This change addresses an issue where a player can lose items from their backpack if opened after their permissions or the plugin configuration were changed to not allow as much space.

https://umod.org/community/backpacks/20710-delete-bottom-slots-when-permission-revoked.

The compaction logic could be improved for the use case where there are multiple stacks in the player inventory or backpack that could already be combined, but that's unlikely to happen and therefore probably isn't worth the effort.

The dropping logic could also be improved to create a container and drop that if there's more than one item, but this is already a good start.

This does not address the use case where permissions to access the backpack are completely revoked, as the player won't even be able to use the backpack command. In that case, the items in their backpack are inaccessible, but not lost.