### PR TITLE
Add permissions to exempt players from losing their backpack on death

### DIFF
--- a/Backpacks.cs
+++ b/Backpacks.cs
@@ -28,6 +28,7 @@ namespace Oxide.Plugins
 
         private const string UsagePermission = "backpacks.use";
         private const string AdminPermission = "backpacks.admin";
+        private const string KeepOnDeathPermission = "backpacks.keepondeath";
 
         private const string BackpackPrefab = "assets/prefabs/misc/item drop/item_drop_backpack.prefab";
 
@@ -52,6 +53,7 @@ namespace Oxide.Plugins
 
             permission.RegisterPermission(UsagePermission, this);
             permission.RegisterPermission(AdminPermission, this);
+            permission.RegisterPermission(KeepOnDeathPermission, this);
 
             for (ushort size = MinSize; size <= MaxSize; size++)
             {
@@ -191,6 +193,9 @@ namespace Oxide.Plugins
                     var backpack = Backpack.Get(player.userID);
 
                     backpack.ForceClose();
+
+                    if (permission.UserHasPermission(player.UserIDString, KeepOnDeathPermission))
+                        return;
 
                     if (_config.EraseOnDeath)
                         backpack.EraseContents();

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Please consider donating to support me and help me put more time into my plugins
 - `backpacks.admin` -- required for `/viewbackpack` command
 - `backpacks.use` -- required to open your own backpack
 - `backpacks.use.1 - 7` -- gives player access to a certain amount of inventory rows overwriting the configured default size *(e.g. backpacks.use.3 gives them 3 rows of item space; still requires backpacks.use)*
+- `backpacks.keepondeath` -- exempts player from having their backpack erased or dropped on death
 
 ## Configuration
 


### PR DESCRIPTION
Addresses the following feature requests:
- https://umod.org/community/backpacks/3633-drop-on-death-disabled-for-admins
- https://umod.org/community/backpacks/12352-allowing-some-players-to-not-drop-backpack-on-death

I made it one permission even though there are two config options since only one of the config options applies at a time since erase-on-death overrides drop-on-death.

I'm aware that people can currently use hooks to exempt players, but the permissions should be more convenient for folks as they don't have to write a plugin to get this functionality.

A player having this permission will prevent the corresponding canDrop/canErase hooks from firing for them, but I'm thinking this generally won't be an issue.