### PR TITLE
Fix using deprecated OnPlayerCorpse hook

### DIFF
--- a/Backpacks.cs
+++ b/Backpacks.cs
@@ -71,7 +71,7 @@ namespace Oxide.Plugins
 
             if (!_config.DropOnDeath || !ConVar.Server.corpses)
             {
-                Unsubscribe("OnPlayerCorpse");
+                Unsubscribe(nameof(OnPlayerCorpseSpawned));
             }
         }
 
@@ -223,7 +223,7 @@ namespace Oxide.Plugins
             }
         }
 
-        private void OnPlayerCorpse(BasePlayer player, BaseCorpse corpse)
+        private void OnPlayerCorpseSpawned(BasePlayer player, BaseCorpse corpse)
         {
             if (!_lastDroppedBackpacks.ContainsKey(player.userID))
                 return;


### PR DESCRIPTION
OnPlayerCorpse is being replaced by OnPlayerCorpseSpawned.
https://umod.org/community/backpacks/25923-deprecated-hook

This was just deprecated as of the latest Oxide update. Not urgent but this will print out in the console of people who have installed this plugin.

Tested with the new hook. It's working great.