### PR TITLE
Add keeponwipe permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Please consider donating to support me and help me put more time into my plugins
 - `backpacks.use.1 - 7` -- gives player access to a certain amount of inventory rows overwriting the configured default size *(e.g. backpacks.use.3 gives them 3 rows of item space; still requires backpacks.use)*
 - `backpacks.fetch` -- required to use the `backpack.fetch` command
 - `backpacks.keepondeath` -- exempts player from having their backpack erased or dropped on death
+- `backpacks.keeponwipe` -- exempts player from having their backpack erased on map wipe
 
 ## Configuration
 


### PR DESCRIPTION
This allows server administrators to exempt privileged players, such as VIPs or admins, from having their backpacks cleared on map wipe.

This solves a problem described in the following support thread.
https://umod.org/community/backpacks/25329-separate-vip-steam-ids-in-data

New log message examples are below.

_[Backpacks] New save created. All backpacks were cleared. Players with the 'backpacks.keeponwipe' permission are exempt. Clearing backpacks can be disabled for all players in the configuration file._

_[Backpacks] New save created. All backpacks were cleared, except 2 due to being exempt. Players with the 'backpacks.keeponwipe' permission are exempt. Clearing backpacks can be disabled for all players in the configuration file._