### PR TITLE
Add noblacklist permission

### DIFF
--- a/Backpacks.cs
+++ b/Backpacks.cs
@@ -31,6 +31,7 @@ namespace Oxide.Plugins
         private const string AdminPermission = "backpacks.admin";
         private const string KeepOnDeathPermission = "backpacks.keepondeath";
         private const string KeepOnWipePermission = "backpacks.keeponwipe";
+        private const string NoBlacklistPermission = "backpacks.noblacklist";
 
         private const string BackpackPrefab = "assets/prefabs/misc/item drop/item_drop_backpack.prefab";
 
@@ -59,6 +60,7 @@ namespace Oxide.Plugins
             permission.RegisterPermission(AdminPermission, this);
             permission.RegisterPermission(KeepOnDeathPermission, this);
             permission.RegisterPermission(KeepOnWipePermission, this);
+            permission.RegisterPermission(NoBlacklistPermission, this);
 
             for (ushort size = MinSize; size <= MaxSize; size++)
             {
@@ -176,7 +178,7 @@ namespace Oxide.Plugins
 
             Backpack backpack = _backpacks.Values.FirstOrDefault(b => b.IsUnderlyingContainer(container));
 
-            if (backpack != null)
+            if (backpack != null && !permission.UserHasPermission(backpack.OwnerIdString, NoBlacklistPermission))
             {
                 // Is the Item blacklisted
                 if (_config.BlacklistedItems.Any(shortName => shortName == item.info.shortname))
@@ -686,11 +688,13 @@ namespace Oxide.Plugins
         private class Backpack
         {
             private bool _initialized = false;
-            private string _ownerIdString;
             private bool _hasPossibleOverflow = false;
 
             private ItemContainer _itemContainer = new ItemContainer();
             private List<BasePlayer> _looters = new List<BasePlayer>();
+
+            [JsonIgnore]
+            public string OwnerIdString { get; private set; }
 
             [JsonProperty("OwnerID")]
             public ulong OwnerId { get; private set; }
@@ -709,7 +713,7 @@ namespace Oxide.Plugins
                 KillContainer();
             }
 
-            public IPlayer FindOwnerPlayer() => _instance.covalence.Players.FindPlayerById(_ownerIdString);
+            public IPlayer FindOwnerPlayer() => _instance.covalence.Players.FindPlayerById(OwnerIdString);
 
             public bool IsUnderlyingContainer(ItemContainer itemContainer) => _itemContainer == itemContainer;
 
@@ -717,7 +721,7 @@ namespace Oxide.Plugins
             {
                 foreach(var kvp in _instance._backpackSizePermissions)
                 {
-                    if (_instance.permission.UserHasPermission(_ownerIdString, kvp.Key))
+                    if (_instance.permission.UserHasPermission(OwnerIdString, kvp.Key))
                         return kvp.Value;
                 }
 
@@ -730,7 +734,7 @@ namespace Oxide.Plugins
             {
                 if (!_initialized)
                 {
-                    _ownerIdString = OwnerId.ToString();
+                    OwnerIdString = OwnerId.ToString();
                 }
                 else
                 {

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Please consider donating to support me and help me put more time into my plugins
 - `backpacks.fetch` -- required to use the `backpack.fetch` command
 - `backpacks.keepondeath` -- exempts player from having their backpack erased or dropped on death
 - `backpacks.keeponwipe` -- exempts player from having their backpack erased on map wipe
+- `backpacks.noblacklist` -- exempts player from the item blacklist
 
 ## Configuration
 


### PR DESCRIPTION
This allows server administrators to exempt privileged players, such as VIPs and admins, from being unable to place blacklisted items in their backpacks.

This feature was requested in the following support thread.
https://umod.org/community/backpacks/18435-allow-admin-to-bypass-blacklisting