### PR TITLE
Add support for toggling the backpack closed

### DIFF
--- a/Backpacks.cs
+++ b/Backpacks.cs
@@ -369,13 +369,21 @@ namespace Oxide.Plugins
             if (player == null || !player.IsAlive())
                 return;
 
-            if (permission.UserHasPermission(player.UserIDString, UsagePermission))
+            if (!permission.UserHasPermission(player.UserIDString, UsagePermission))
             {
-                player.EndLooting();
-                timer.Once(0.1f, () => Backpack.Get(player.userID).Open(player));
-            }
-            else
                 PrintToChat(player, lang.GetMessage("No Permission", this, player.UserIDString));
+                return;
+            }
+
+            if (_openBackpacks.ContainsKey(player))
+            {
+                // HACK: Send empty respawn information to fully close the player inventory (toggle backpack closed)
+                player.ClientRPCPlayer(null, player, "OnRespawnInformation");
+                return;
+            }
+
+            player.EndLooting();
+            timer.Once(0.1f, () => Backpack.Get(player.userID).Open(player));
         }
 
         [ConsoleCommand("backpack.fetch")]


### PR DESCRIPTION
This makes it so that running the `backpack.open` console command will toggle the player inventory closed if the backpack is already open. We could potentially make this a config option or a separate command, but I don't see any harm in making this the default behavior for now.

Requested here:
https://umod.org/community/backpacks/28834-possible-to-bind-key-to-toggle

Solution was suggested here:
https://umod.org/community/backpacks/28950-toggle-instead-of-just-opening

Solution also described here (basic google search):
https://oxidemod.org/threads/closing-players-inventory.7523/