### PR TITLE
New API method to get all existing ItemContainers

### DIFF
--- a/Backpacks.cs
+++ b/Backpacks.cs
@@ -16,7 +16,7 @@ using UnityEngine;
 
 namespace Oxide.Plugins
 {
-    [Info("Backpacks", "LaserHydra", "3.4.0")]
+    [Info("Backpacks", "LaserHydra", "3.4.1")]
     [Description("Allows players to have a Backpack which provides them extra inventory space.")]
     internal class Backpacks : RustPlugin
     {
@@ -855,6 +855,13 @@ namespace Oxide.Plugins
 
         #region Backpack
 
+        #region API
+
+        private Dictionary<ulong, ItemContainer> API_GetExistingBackpacks()
+        {
+            return _backpacks.ToDictionary(x => x.Key, x => x.Value.GetContainer());
+        }
+
         private DroppedItemContainer API_DropBackpack(BasePlayer player)
         {
             if (!Backpack.HasBackpackFile(player.userID))
@@ -865,6 +872,8 @@ namespace Oxide.Plugins
 
             return DropBackpackWithReducedCorpseCollision(backpack, player.transform.position);
         }
+
+        #endregion
 
         private class Backpack
         {
@@ -907,6 +916,8 @@ namespace Oxide.Plugins
 
                 return _instance._config.BackpackSize;
             }
+
+            public ItemContainer GetContainer() => _itemContainer;
 
             private int GetAllowedCapacity() => GetAllowedSize() * SlotsPerRow;
 


### PR DESCRIPTION
In my case - I have a plugin where I need to get all items existing on the server, and while the backpacks does not have an entity - that's the only way I came up with :)