### PR TITLE
NullReferenceException on server start fix + more accurate RemoveGUI

### DIFF
--- a/Backpacks.cs
+++ b/Backpacks.cs
@@ -57,48 +57,14 @@ namespace Oxide.Plugins
 
         private void Init()
         {
-            Unsubscribe(nameof(CanAcceptItem));
-            Unsubscribe(nameof(CanLootPlayer));
-            Unsubscribe(nameof(OnEntityDeath));
-            Unsubscribe(nameof(OnEntityKill));
-            Unsubscribe(nameof(OnGroupPermissionGranted));
-            Unsubscribe(nameof(OnGroupPermissionRevoked));
-            Unsubscribe(nameof(OnNewSave));
-            Unsubscribe(nameof(OnPlayerConnected));
-            Unsubscribe(nameof(OnPlayerCorpseSpawned));
-            Unsubscribe(nameof(OnPlayerDisconnected));
-            Unsubscribe(nameof(OnPlayerLootEnd));
-            Unsubscribe(nameof(OnPlayerRespawned));
             Unsubscribe(nameof(OnPlayerSleep));
             Unsubscribe(nameof(OnPlayerSleepEnded));
-            Unsubscribe(nameof(OnServerSave));
-            Unsubscribe(nameof(OnUserGroupAdded));
-            Unsubscribe(nameof(OnUserGroupRemoved));
-            Unsubscribe(nameof(OnUserPermissionGranted));
-            Unsubscribe(nameof(OnUserPermissionRevoked));
         }
 
         private void OnServerInitialized()
         {
-            Subscribe(nameof(CanAcceptItem));
-            Subscribe(nameof(CanLootPlayer));
-            Subscribe(nameof(OnEntityDeath));
-            Subscribe(nameof(OnEntityKill));
-            Subscribe(nameof(OnGroupPermissionGranted));
-            Subscribe(nameof(OnGroupPermissionRevoked));
-            Subscribe(nameof(OnNewSave));
-            Subscribe(nameof(OnPlayerConnected));
-            Subscribe(nameof(OnPlayerCorpseSpawned));
-            Subscribe(nameof(OnPlayerDisconnected));
-            Subscribe(nameof(OnPlayerLootEnd));
-            Subscribe(nameof(OnPlayerRespawned));
             Subscribe(nameof(OnPlayerSleep));
             Subscribe(nameof(OnPlayerSleepEnded));
-            Subscribe(nameof(OnServerSave));
-            Subscribe(nameof(OnUserGroupAdded));
-            Subscribe(nameof(OnUserGroupRemoved));
-            Subscribe(nameof(OnUserPermissionGranted));
-            Subscribe(nameof(OnUserPermissionRevoked));
         }
 
         private void Loaded()
@@ -335,18 +301,6 @@ namespace Oxide.Plugins
                     }
                 }
             }
-        }
-
-        private void OnUserGroupAdded(string userId, string groupName)
-        {
-            if (permission.GroupHasPermission(groupName, GUIPermission))
-                CreateGUI(BasePlayer.Find(userId));
-        }
-
-        private void OnUserGroupRemoved(string userId, string groupName)
-        {
-            if (permission.GroupHasPermission(groupName, GUIPermission) && !permission.UserHasPermission(userId, GUIPermission))
-                DestroyGUI(BasePlayer.Find(userId));
         }
 
         private void OnUserPermissionGranted(string userId, string perm)

--- a/Backpacks.cs
+++ b/Backpacks.cs
@@ -55,6 +55,52 @@ namespace Oxide.Plugins
 
         #region Hooks
 
+        private void Init()
+        {
+            Unsubscribe(nameof(CanAcceptItem));
+            Unsubscribe(nameof(CanLootPlayer));
+            Unsubscribe(nameof(OnEntityDeath));
+            Unsubscribe(nameof(OnEntityKill));
+            Unsubscribe(nameof(OnGroupPermissionGranted));
+            Unsubscribe(nameof(OnGroupPermissionRevoked));
+            Unsubscribe(nameof(OnNewSave));
+            Unsubscribe(nameof(OnPlayerConnected));
+            Unsubscribe(nameof(OnPlayerCorpseSpawned));
+            Unsubscribe(nameof(OnPlayerDisconnected));
+            Unsubscribe(nameof(OnPlayerLootEnd));
+            Unsubscribe(nameof(OnPlayerRespawned));
+            Unsubscribe(nameof(OnPlayerSleep));
+            Unsubscribe(nameof(OnPlayerSleepEnded));
+            Unsubscribe(nameof(OnServerSave));
+            Unsubscribe(nameof(OnUserGroupAdded));
+            Unsubscribe(nameof(OnUserGroupRemoved));
+            Unsubscribe(nameof(OnUserPermissionGranted));
+            Unsubscribe(nameof(OnUserPermissionRevoked));
+        }
+
+        private void OnServerInitialized()
+        {
+            Subscribe(nameof(CanAcceptItem));
+            Subscribe(nameof(CanLootPlayer));
+            Subscribe(nameof(OnEntityDeath));
+            Subscribe(nameof(OnEntityKill));
+            Subscribe(nameof(OnGroupPermissionGranted));
+            Subscribe(nameof(OnGroupPermissionRevoked));
+            Subscribe(nameof(OnNewSave));
+            Subscribe(nameof(OnPlayerConnected));
+            Subscribe(nameof(OnPlayerCorpseSpawned));
+            Subscribe(nameof(OnPlayerDisconnected));
+            Subscribe(nameof(OnPlayerLootEnd));
+            Subscribe(nameof(OnPlayerRespawned));
+            Subscribe(nameof(OnPlayerSleep));
+            Subscribe(nameof(OnPlayerSleepEnded));
+            Subscribe(nameof(OnServerSave));
+            Subscribe(nameof(OnUserGroupAdded));
+            Subscribe(nameof(OnUserGroupRemoved));
+            Subscribe(nameof(OnUserPermissionGranted));
+            Subscribe(nameof(OnUserPermissionRevoked));
+        }
+
         private void Loaded()
         {
             _instance = this;
@@ -283,9 +329,24 @@ namespace Oxide.Plugins
             {
                 foreach (IPlayer player in covalence.Players.Connected.Where(p => permission.UserHasGroup(p.Id, group)))
                 {
-                    DestroyGUI(player.Object as BasePlayer);
+                    if (!permission.UserHasPermission(player.Id, GUIPermission))
+                    {
+                        DestroyGUI(player.Object as BasePlayer);
+                    }
                 }
             }
+        }
+
+        private void OnUserGroupAdded(string userId, string groupName)
+        {
+            if (permission.GroupHasPermission(groupName, GUIPermission))
+                CreateGUI(BasePlayer.Find(userId));
+        }
+
+        private void OnUserGroupRemoved(string userId, string groupName)
+        {
+            if (permission.GroupHasPermission(groupName, GUIPermission) && !permission.UserHasPermission(userId, GUIPermission))
+                DestroyGUI(BasePlayer.Find(userId));
         }
 
         private void OnUserPermissionGranted(string userId, string perm)
@@ -296,7 +357,7 @@ namespace Oxide.Plugins
 
         private void OnUserPermissionRevoked(string userId, string perm)
         {
-            if (perm.Equals(GUIPermission))
+            if (perm.Equals(GUIPermission) && !permission.UserHasPermission(userId, GUIPermission))
                 DestroyGUI(BasePlayer.Find(userId));
         }
 


### PR DESCRIPTION
- Added hook to watch adding/excluding player in/from group with GUI permission.
- Prevent destroying GUI for player that actually has permission.
- Fix for ```[Error] Failed to call hook 'OnPlayerSleep' on plugin 'Backpacks v3.5.2' (NullReferenceException: Object reference not set to an instance of an object) at Oxide.Game.Rust.Cui.CuiHelper.DestroyUi (BasePlayer player, System.String elem) [0x00035] in <63125a832d1b447fb368c2d12baf4406>:0 at Oxide.Plugins.Backpacks.DestroyGUI (BasePlayer player) [0x0000c] in <22423bf8504849d3bb35db37a86ba3c4>:0 at Oxide.Plugins.Backpacks.OnPlayerSleep (BasePlayer player) [0x00000] in <22423bf8504849d3bb35db37a86ba3c4>:0 at Oxide.Plugins.Backpacks.DirectCallHook (System.String name, System.Object& ret, System.Object[] args) [0x00353] in <22423bf8504849d3bb35db37a86ba3c4>:0 at Oxide.Plugins.CSharpPlugin.InvokeMethod (Oxide.Core.Plugins.HookMethod method, System.Object[] args) [0x00079] in <3606d2af539c45e4b5c61658e6a8b307>:0 at Oxide.Core.Plugins.CSPlugin.OnCallHook (System.String name, System.Object[] args) [0x000d8] in <c2afd8354b8b4f3ca451cf5a1aa111c3>:0 at Oxide.Core.Plugins.Plugin.CallHook (System.String hook, System.Object[] args) [0x00060] in <c2afd8354b8b4f3ca451cf5a1aa111c3>:0```