### PR TITLE
API for capacity of Backpack w/o BasePlayer

### DIFF
--- a/Backpacks.cs
+++ b/Backpacks.cs
@@ -484,7 +484,7 @@ namespace Oxide.Plugins
                     [nameof(IsBackpackLoaded)] = new Func<BasePlayer, bool>(IsBackpackLoaded),
                     [nameof(IsDynamicCapacityEnabled)] = new Func<bool>(IsDynamicCapacityEnabled),
                     [nameof(GetBackpackCapacity)] = new Func<BasePlayer, int>(GetBackpackCapacity),
-                    [nameof(GetBackpackCapacityByIPlayer)] = new Func<IPlayer, int>(GetBackpackCapacityByIPlayer),
+                    [nameof(GetBackpackCapacityById)] = new Func<ulong, string, int>(GetBackpackCapacityById),
                     [nameof(GetBackpackInitialCapacity)] = new Func<BasePlayer, int>(GetBackpackInitialCapacity),
                     [nameof(GetBackpackMaxCapacity)] = new Func<BasePlayer, int>(GetBackpackMaxCapacity),
                     [nameof(AddBackpackCapacity)] = new Func<BasePlayer, int, int>(AddBackpackCapacity),
@@ -564,9 +564,9 @@ namespace Oxide.Plugins
                 return _plugin._capacityManager.GetCapacity(player.userID, player.UserIDString);
             }
             
-            public int GetBackpackCapacityByIPlayer(IPlayer player)
+            public int GetBackpackCapacityById(ulong playerID, string playerIDString)
             {
-                return _plugin._capacityManager.GetCapacity(Convert.ToUInt64(player.Id), player.Id);
+                return _plugin._capacityManager.GetCapacity(playerID, playerIDString);
             }
 
             public int GetBackpackInitialCapacity(BasePlayer player)
@@ -734,10 +734,10 @@ namespace Oxide.Plugins
             return ObjectCache.Get(_api.GetBackpackCapacity(player));
         }
         
-        [HookMethod(nameof(API_GetBackpackCapacityByIPlayer))]
-        public object API_GetBackpackCapacityByIPlayer(IPlayer player)
+        [HookMethod(nameof(API_GetBackpackCapacityById))]
+        public object API_GetBackpackCapacityById(ulong playerID, string playerIDString)
         {
-            return ObjectCache.Get(_api.GetBackpackCapacityByIPlayer(player));
+            return ObjectCache.Get(_api.GetBackpackCapacityById(playerID, playerIDString));
         }
 
         [HookMethod(nameof(API_GetBackpackInitialCapacity))]

--- a/Backpacks.cs
+++ b/Backpacks.cs
@@ -1,4 +1,4 @@
-// #define DEBUG_DROP_ON_DEATH
+﻿// #define DEBUG_DROP_ON_DEATH
 // #define DEBUG_POOLING
 // #define DEBUG_BACKPACK_LIFECYCLE
 
@@ -484,7 +484,6 @@ namespace Oxide.Plugins
                     [nameof(IsBackpackLoaded)] = new Func<BasePlayer, bool>(IsBackpackLoaded),
                     [nameof(IsDynamicCapacityEnabled)] = new Func<bool>(IsDynamicCapacityEnabled),
                     [nameof(GetBackpackCapacity)] = new Func<BasePlayer, int>(GetBackpackCapacity),
-                    [nameof(GetBackpackCapacityById)] = new Func<ulong, string, int>(GetBackpackCapacityById),
                     [nameof(GetBackpackInitialCapacity)] = new Func<BasePlayer, int>(GetBackpackInitialCapacity),
                     [nameof(GetBackpackMaxCapacity)] = new Func<BasePlayer, int>(GetBackpackMaxCapacity),
                     [nameof(AddBackpackCapacity)] = new Func<BasePlayer, int, int>(AddBackpackCapacity),
@@ -562,11 +561,6 @@ namespace Oxide.Plugins
             public int GetBackpackCapacity(BasePlayer player)
             {
                 return _plugin._capacityManager.GetCapacity(player.userID, player.UserIDString);
-            }
-            
-            public int GetBackpackCapacityById(ulong playerID, string playerIDString)
-            {
-                return _plugin._capacityManager.GetCapacity(playerID, playerIDString);
             }
 
             public int GetBackpackInitialCapacity(BasePlayer player)
@@ -732,12 +726,6 @@ namespace Oxide.Plugins
         public object API_GetBackpackCapacity(BasePlayer player)
         {
             return ObjectCache.Get(_api.GetBackpackCapacity(player));
-        }
-        
-        [HookMethod(nameof(API_GetBackpackCapacityById))]
-        public object API_GetBackpackCapacityById(ulong playerID, string playerIDString)
-        {
-            return ObjectCache.Get(_api.GetBackpackCapacityById(playerID, playerIDString));
         }
 
         [HookMethod(nameof(API_GetBackpackInitialCapacity))]

--- a/Backpacks.cs
+++ b/Backpacks.cs
@@ -1,4 +1,4 @@
-// #define DEBUG_DROP_ON_DEATH
+﻿// #define DEBUG_DROP_ON_DEATH
 // #define DEBUG_POOLING
 // #define DEBUG_BACKPACK_LIFECYCLE
 
@@ -484,7 +484,6 @@ namespace Oxide.Plugins
                     [nameof(IsBackpackLoaded)] = new Func<BasePlayer, bool>(IsBackpackLoaded),
                     [nameof(IsDynamicCapacityEnabled)] = new Func<bool>(IsDynamicCapacityEnabled),
                     [nameof(GetBackpackCapacity)] = new Func<BasePlayer, int>(GetBackpackCapacity),
-                    [nameof(GetBackpackCapacityByIPlayer)] = new Func<IPlayer, int>(GetBackpackCapacityByIPlayer),
                     [nameof(GetBackpackInitialCapacity)] = new Func<BasePlayer, int>(GetBackpackInitialCapacity),
                     [nameof(GetBackpackMaxCapacity)] = new Func<BasePlayer, int>(GetBackpackMaxCapacity),
                     [nameof(AddBackpackCapacity)] = new Func<BasePlayer, int, int>(AddBackpackCapacity),
@@ -562,11 +561,6 @@ namespace Oxide.Plugins
             public int GetBackpackCapacity(BasePlayer player)
             {
                 return _plugin._capacityManager.GetCapacity(player.userID, player.UserIDString);
-            }
-            
-            public int GetBackpackCapacityByIPlayer(IPlayer player)
-            {
-                return _plugin._capacityManager.GetCapacity(Convert.ToUInt64(player.Id), player.Id);
             }
 
             public int GetBackpackInitialCapacity(BasePlayer player)
@@ -732,12 +726,6 @@ namespace Oxide.Plugins
         public object API_GetBackpackCapacity(BasePlayer player)
         {
             return ObjectCache.Get(_api.GetBackpackCapacity(player));
-        }
-        
-        [HookMethod(nameof(API_GetBackpackCapacityByIPlayer))]
-        public object API_GetBackpackCapacityByIPlayer(IPlayer player)
-        {
-            return ObjectCache.Get(_api.GetBackpackCapacityByIPlayer(player));
         }
 
         [HookMethod(nameof(API_GetBackpackInitialCapacity))]

--- a/Backpacks.cs
+++ b/Backpacks.cs
@@ -1,4 +1,4 @@
-﻿// #define DEBUG_DROP_ON_DEATH
+// #define DEBUG_DROP_ON_DEATH
 // #define DEBUG_POOLING
 // #define DEBUG_BACKPACK_LIFECYCLE
 
@@ -484,6 +484,7 @@ namespace Oxide.Plugins
                     [nameof(IsBackpackLoaded)] = new Func<BasePlayer, bool>(IsBackpackLoaded),
                     [nameof(IsDynamicCapacityEnabled)] = new Func<bool>(IsDynamicCapacityEnabled),
                     [nameof(GetBackpackCapacity)] = new Func<BasePlayer, int>(GetBackpackCapacity),
+                    [nameof(GetBackpackCapacityByIPlayer)] = new Func<IPlayer, int>(GetBackpackCapacityByIPlayer),
                     [nameof(GetBackpackInitialCapacity)] = new Func<BasePlayer, int>(GetBackpackInitialCapacity),
                     [nameof(GetBackpackMaxCapacity)] = new Func<BasePlayer, int>(GetBackpackMaxCapacity),
                     [nameof(AddBackpackCapacity)] = new Func<BasePlayer, int, int>(AddBackpackCapacity),
@@ -561,6 +562,11 @@ namespace Oxide.Plugins
             public int GetBackpackCapacity(BasePlayer player)
             {
                 return _plugin._capacityManager.GetCapacity(player.userID, player.UserIDString);
+            }
+            
+            public int GetBackpackCapacityByIPlayer(IPlayer player)
+            {
+                return _plugin._capacityManager.GetCapacity(Convert.ToUInt64(player.Id), player.Id);
             }
 
             public int GetBackpackInitialCapacity(BasePlayer player)
@@ -726,6 +732,12 @@ namespace Oxide.Plugins
         public object API_GetBackpackCapacity(BasePlayer player)
         {
             return ObjectCache.Get(_api.GetBackpackCapacity(player));
+        }
+        
+        [HookMethod(nameof(API_GetBackpackCapacityByIPlayer))]
+        public object API_GetBackpackCapacityByIPlayer(IPlayer player)
+        {
+            return ObjectCache.Get(_api.GetBackpackCapacityByIPlayer(player));
         }
 
         [HookMethod(nameof(API_GetBackpackInitialCapacity))]

--- a/Backpacks.cs
+++ b/Backpacks.cs
@@ -484,6 +484,7 @@ namespace Oxide.Plugins
                     [nameof(IsBackpackLoaded)] = new Func<BasePlayer, bool>(IsBackpackLoaded),
                     [nameof(IsDynamicCapacityEnabled)] = new Func<bool>(IsDynamicCapacityEnabled),
                     [nameof(GetBackpackCapacity)] = new Func<BasePlayer, int>(GetBackpackCapacity),
+                    [nameof(GetBackpackCapacityByIPlayer)] = new Func<IPlayer, int>(GetBackpackCapacityByIPlayer),
                     [nameof(GetBackpackInitialCapacity)] = new Func<BasePlayer, int>(GetBackpackInitialCapacity),
                     [nameof(GetBackpackMaxCapacity)] = new Func<BasePlayer, int>(GetBackpackMaxCapacity),
                     [nameof(AddBackpackCapacity)] = new Func<BasePlayer, int, int>(AddBackpackCapacity),
@@ -561,6 +562,11 @@ namespace Oxide.Plugins
             public int GetBackpackCapacity(BasePlayer player)
             {
                 return _plugin._capacityManager.GetCapacity(player.userID, player.UserIDString);
+            }
+            
+            public int GetBackpackCapacityByIPlayer(IPlayer player)
+            {
+                return _plugin._capacityManager.GetCapacity(Convert.ToUInt64(player.Id), player.Id);
             }
 
             public int GetBackpackInitialCapacity(BasePlayer player)
@@ -726,6 +732,12 @@ namespace Oxide.Plugins
         public object API_GetBackpackCapacity(BasePlayer player)
         {
             return ObjectCache.Get(_api.GetBackpackCapacity(player));
+        }
+        
+        [HookMethod(nameof(API_GetBackpackCapacityByIPlayer))]
+        public object API_GetBackpackCapacityByIPlayer(IPlayer player)
+        {
+            return ObjectCache.Get(_api.GetBackpackCapacityByIPlayer(player));
         }
 
         [HookMethod(nameof(API_GetBackpackInitialCapacity))]

--- a/Backpacks.cs
+++ b/Backpacks.cs
@@ -8971,7 +8971,7 @@ namespace Oxide.Plugins
                     throw new ArgumentOutOfRangeException(nameof(gatherMode), gatherMode, null);
             }
         }
-
+// Comment Test
         protected override void LoadDefaultMessages()
         {
             var englishLangKeys = new Dictionary<string, string>();

--- a/Backpacks.cs
+++ b/Backpacks.cs
@@ -8971,7 +8971,7 @@ namespace Oxide.Plugins
                     throw new ArgumentOutOfRangeException(nameof(gatherMode), gatherMode, null);
             }
         }
-// Comment Test
+
         protected override void LoadDefaultMessages()
         {
             var englishLangKeys = new Dictionary<string, string>();


### PR DESCRIPTION
Adds API for retrieving Capacity of a backpack via ulong steamID + string steamID. This is an alternative for the BasePlayer version since the capabilities were there to begin with but just weren't included in the API. This will help in cases where the BasePlayer doesn't exist, for example when they are offline and dead.